### PR TITLE
Generate Pending Rewards

### DIFF
--- a/account_holders_generator/cli.py
+++ b/account_holders_generator/cli.py
@@ -95,6 +95,12 @@ from .src.vela.db import load_models as load_vela_models
     default=False,
     help=("Sets up retailer, campaign, and reward config in addition to the usual account holders and rewards."),
 )
+@click.option(
+    "--refund-window",
+    "refund_window",
+    default=0,
+    help="Sets a refund window for reward rule. If reward goal is reached, pending rewards are created.",
+)
 def main(
     account_holders_to_create: int,
     retailer: str,
@@ -110,6 +116,7 @@ def main(
     carina_db_name: str,
     unallocated_rewards_to_create: int,
     setup_retailer: bool,
+    refund_window: int,
 ) -> None:
 
     if max_val < 0:
@@ -139,6 +146,7 @@ def main(
                 retailer,
                 campaign,
                 reward_slug,
+                refund_window,
             )
 
         generate_account_holders_and_rewards(
@@ -150,6 +158,7 @@ def main(
             campaign,
             max_val,
             unallocated_rewards_to_create,
+            refund_window,
         )
     finally:
         carina_db_session.close()

--- a/account_holders_generator/src/fixtures.py
+++ b/account_holders_generator/src/fixtures.py
@@ -129,6 +129,27 @@ def account_holder_reward_payload(
     }
 
 
+def account_holder_pending_reward_payload(
+    account_holder_id: int,
+    retailer_slug: str,
+    reward_slug: str,
+    campaign_slug: str,
+    refund_window: int,
+) -> dict:
+    now = datetime.now(tz=timezone.utc)
+
+    return {
+        "created_date": now,
+        "conversion_date": now + timedelta(days=refund_window),
+        "value": 200,
+        "account_holder_id": account_holder_id,
+        "retailer_slug": retailer_slug,
+        "campaign_slug": campaign_slug,
+        "reward_slug": reward_slug,
+        "idempotency_token": str(uuid4()),
+    }
+
+
 def reward_payload(reward_uuid: UUID, reward_code: str, reward_config_id: int, retailer_slug: str) -> dict:
     return {
         "id": reward_uuid,
@@ -185,12 +206,16 @@ def campaign_payload(retailer_id: int, campaign_slug: str) -> dict:
     }
 
 
-def reward_rule_payload(campaign_id: int, reward_slug: str) -> dict:
-    return {
+def reward_rule_payload(campaign_id: int, reward_slug: str, refund_window: int) -> dict:
+    payload = {
         "campaign_id": campaign_id,
         "reward_slug": reward_slug,
         "reward_goal": 200,
     }
+    if refund_window is not None:
+        payload.update({"allocation_window": refund_window})
+
+    return payload
 
 
 def earn_rule_payload(campaign_id: int) -> dict:

--- a/account_holders_generator/src/generator.py
+++ b/account_holders_generator/src/generator.py
@@ -35,6 +35,7 @@ def generate_account_holders_and_rewards(
     campaign_slug: str,
     max_val: int,
     unallocated_rewards_to_create: int,
+    refund_window: int,
 ) -> None:
 
     retailer = get_retailer_by_slug(polaris_db_session, retailer_slug)
@@ -79,6 +80,7 @@ def generate_account_holders_and_rewards(
                     progress_counter=progress_counter,
                     account_holder_type_reward_code_salt=str(uuid4()),
                     reward_config=reward_config,
+                    refund_window=refund_window,
                 )
                 persist_allocated_rewards(carina_db_session, matching_reward_payloads_batch)
                 batch_start = batch_end
@@ -91,10 +93,11 @@ def generate_retailer_base_config(
     retailer_slug: str,
     campaign_slug: str,
     reward_slug: str,
+    refund_window: int,
 ) -> None:
     click.echo("Creating '%s' retailer in Polaris." % retailer_slug)
     setup_retailer_config(polaris_db_session, retailer_slug)
     click.echo("Creating '%s' campaign in Vela." % campaign_slug)
-    setup_retailer_reward_and_campaign(vela_db_session, retailer_slug, campaign_slug, reward_slug)
+    setup_retailer_reward_and_campaign(vela_db_session, retailer_slug, campaign_slug, reward_slug, refund_window)
     click.echo("Creating '%s' reward config in Carina." % reward_slug)
     setup_reward_config(carina_db_session, retailer_slug, reward_slug)

--- a/account_holders_generator/src/polaris/db.py
+++ b/account_holders_generator/src/polaris/db.py
@@ -48,6 +48,12 @@ class AccountHolderReward(Base):
     account_holder_id = Column(BIGINT, ForeignKey("account_holder.id", ondelete="CASCADE"))
 
 
+class PendingReward(Base):
+    __tablename__ = "pending_reward"
+
+    account_holder_id = Column(BIGINT, ForeignKey("account_holder.id", ondelete="CASCADE"))
+
+
 class AccountHolderCampaignBalance(Base):
     __tablename__ = "account_holder_campaign_balance"
 

--- a/account_holders_generator/src/vela/crud.py
+++ b/account_holders_generator/src/vela/crud.py
@@ -28,7 +28,7 @@ def get_active_campaigns(db_session: "Session", retailer: "RetailerConfig", camp
 
 
 def setup_retailer_reward_and_campaign(
-    db_session: "Session", retailer_slug: str, campaign_slug: str, reward_slug: str
+    db_session: "Session", retailer_slug: str, campaign_slug: str, reward_slug: str, refund_window: int
 ) -> None:
     db_session.execute(
         delete(RetailerRewards)
@@ -41,6 +41,6 @@ def setup_retailer_reward_and_campaign(
     campaign = Campaign(**campaign_payload(retailer.id, campaign_slug))
     db_session.add(campaign)
     db_session.flush()
-    db_session.add(RewardRule(**reward_rule_payload(campaign.id, reward_slug)))
+    db_session.add(RewardRule(**reward_rule_payload(campaign.id, reward_slug, refund_window)))
     db_session.add(EarnRule(**earn_rule_payload(campaign.id)))
     db_session.commit()


### PR DESCRIPTION
The pending rewards will only be generated when the `--refund-window` flag is used

example cmd: 

`pipenv run python run.py -n 1 -r test-retailer --port 5555 --password pass -c 10percentoff --unallocated-rewards 10 --bootstrap-new-retailer --refund-window 5`